### PR TITLE
LDAP working in docker on local build

### DIFF
--- a/amundsencommon/amundsen_common/models/user.py
+++ b/amundsencommon/amundsen_common/models/user.py
@@ -87,13 +87,3 @@ class UserSchema(AttrsSchema):
 
         if self._str_no_value(data.get('user_id')):
             raise ValidationError('"user_id" or "email" must be provided')
-
-def get_user_details(user_id) -> None:
-    user_info = {
-        'email': 'test@email.com',
-        'user_id': user_id,
-        'first_name': 'Firstname',
-        'last_name': 'Lastname',
-        'full_name': 'Firstname Lastname',
-    }
-    return user_info

--- a/amundsenmetadatalibrary/public.Dockerfile
+++ b/amundsenmetadatalibrary/public.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim as base
+FROM python:3.7 as base
 WORKDIR /app
 RUN pip3 install gunicorn
 
@@ -8,6 +8,11 @@ RUN pip3 install -r requirements.txt
 # RUN pip3 install -i http://127.0.0.1:3141/testuser/dev -r requirements-internal.txt
 
 COPY . /app
+
+# LDAP install
+RUN apt-get update
+RUN apt-get install -y build-essential python3-dev libldap2-dev libsasl2-dev ldap-utils tox lcov valgrind
+RUN pip3 install python-ldap
 
 CMD [ "python3", "metadata_service/metadata_wsgi.py" ]
 


### PR DESCRIPTION
Make sure to have the following files in your amundsenmetadata root folder:
- CACERT (for macbook users /etc/ssl/cert.pem)
- goog.crt (provided by techops)
- goog.key (provided by techops)

Currently ldap client is created in global context, but ideally this should be different for deployed context vs local build context.
